### PR TITLE
[packagechooser.conf] Gnome replacing totem with showtime

### DIFF
--- a/data/eos/modules/packagechooser.conf
+++ b/data/eos/modules/packagechooser.conf
@@ -230,7 +230,7 @@ items:
             - gvfs-smb
             - nautilus
             - sushi
-            - totem
+            - showtime
             - xdg-desktop-portal-gnome
             - xdg-desktop-portal
             - xdg-user-dirs-gtk


### PR DESCRIPTION
resync 